### PR TITLE
Fixed service dependency method with correct API verb

### DIFF
--- a/lib/pd.js
+++ b/lib/pd.js
@@ -1022,7 +1022,7 @@ this.serviceDependencies = {
     },    
     getBusinessServiceDependencies: async(id) => {
         try {
-            return await request(this.options('service_dependencies/business_services/'+ id, 'POST', null, null))
+            return await request(this.options('service_dependencies/business_services/'+ id, 'GET', null, null))
         }
         catch (err) {
             throw new Error(err)
@@ -1030,7 +1030,7 @@ this.serviceDependencies = {
     },    
     getTechnicalServiceDependencies: async(id) => {
         try {
-            return await request(this.options('service_dependencies/technical_services/'+ id, 'POST', null, null))
+            return await request(this.options('service_dependencies/technical_services/'+ id, 'GET', null, null))
         }
         catch (err) {
             throw new Error(err)


### PR DESCRIPTION
Haven't run the tests, but I encountered this error while actually trying to use these methods.
Replacing 'POST' with 'GET' fixed the issue locally in my node_modules.